### PR TITLE
Search app/models as well as all subdirectories in the sunspot:mongo:reindex task

### DIFF
--- a/lib/sunspot/mongo/tasks.rb
+++ b/lib/sunspot/mongo/tasks.rb
@@ -5,7 +5,7 @@ namespace :sunspot do
       sunspot_models = if args[:models]
          args[:models].split('+').map{|m| m.constantize}
       else
-        all_files = Dir.glob(Rails.root.join('app', 'models', '*.rb'))
+        all_files = Dir.glob(Rails.root.join('app', 'models', '**', '*.rb'))
         all_models = all_files.map { |path| File.basename(path, '.rb').camelize.constantize }
         all_models.select { |m| m.include?(Sunspot::Mongo) and m.searchable? }
       end


### PR DESCRIPTION
I'm working on a project that has multiple levels of subdirectories under app/models. This patch makes the sunspot:mongo:reindex task look in app/models as well as any subdirectories (and sub-sub-directories, etc.) for models that need reindexing.
