### PR TITLE
Fixed rake reindex bug when models are namespaced

### DIFF
--- a/lib/sunspot/mongo/tasks.rb
+++ b/lib/sunspot/mongo/tasks.rb
@@ -6,7 +6,11 @@ namespace :sunspot do
                          args[:models].split('+').map(&:constantize)
                        else
                          all_files = Dir.glob(Rails.root.join('app', 'models', '**', '*.rb'))
-                         all_models = all_files.map { |path| File.basename(path, '.rb').camelize.constantize }
+                         all_models = all_files.map do |path|
+                           dir = Pathname.new(path).relative_path_from(Rails.root.join('app/models'))
+                           dir = dir.to_s.gsub(/#{File.extname(dir)}$/, '')
+                           dir.camelize.constantize
+                         end
                          all_models.select { |m| m.include?(Sunspot::Mongo) && m.searchable? }
                        end
 


### PR DESCRIPTION
The rake reindex task did not take into account the path from app/models to the actual file. So if the Models where namespaced it would throw Uninitialized Constant errors.

This fix rectifies this.

greetings Daniel
