### PR TITLE
fix eager loading of associations . fix sunspot:mongo:reindex task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 * Your contribution here.
 
+#### 1.2.0 (2015/08/28)
+
+* [#9](https://github.com/derekharmel/sunspot_mongo/pull/9): Changed `DataAccessor` to fix support for eager loading of associations - [@cec](https://github.com/cec).
+* [#9](https://github.com/derekharmel/sunspot_mongo/pull/9): Changed `rake sunspot:mongo:reindex` to support namespaced models - [@cec](https://github.com/cec).
+* [#9](https://github.com/derekharmel/sunspot_mongo/pull/9): Renamed `rake sunspot:mongo:reindex` to `rake sunspot:reindex`, overriding Sunspot's original task - [@cec](https://github.com/cec).
+* [#9](https://github.com/derekharmel/sunspot_mongo/pull/9): Added UPGRADING - [@cec](https://github.com/cec).
+
 #### 1.1.0 (2015/01/27)
 
 * Changed `DataAccessor#load_all` to use the `.find` method for MongoMapper and Mongoid for loading a group of documents - [@derekharmel](https://github.com/derekharmel).

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ rails g sunspot_rails:install
 rake sunspot:solr:start
 ```
 
+## Upgrading
+
+When upgrading to a new version, don't forget to check [UPGRADING](UPGRADING.md) for notes about breaking changes.
+
 ## Usage
 
 Add the following to your model (assuming you have a string field named "content"):
@@ -64,7 +68,7 @@ If you are using Rails, objects are automatically indexed to Solr as a part of t
 If you make a change to the object's "schema" (code in the searchable block), you must reindex all objects so the changes are reflected in Solr. Run:
 
 ```
-bundle exec rake sunspot:mongo:reindex
+bundle exec rake sunspot:reindex
 ```
 
 ## More info

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,8 @@
+Upgrading SunspotMongo
+======================
+
+### Upgrading to >= 1.2.0
+
+The Rake task `sunspot:mongo:reindex` has been renamed to `sunspot:reindex` and now overrides the original Rake task from Sunspot.
+
+See [#9](https://github.com/derekhamel/sunspot_mongo/pull/9) for more information.

--- a/lib/sunspot/mongo.rb
+++ b/lib/sunspot/mongo.rb
@@ -18,12 +18,25 @@ module Sunspot
     end
 
     class DataAccessor < Sunspot::Adapters::DataAccessor
+      attr_accessor :include
+
+      # inspired by how Sunspot does this for ActiveRecord
+      def initialize(clazz)
+        super(clazz)
+        @inherited_attributes = [:include]
+      end
+
       def load(id)
-        @clazz.find(id)
+        scope.find(id)
       end
 
       def load_all(ids)
-        @clazz.find(ids)
+        scope.find(ids)
+      end
+
+      def scope
+        sc = @clazz.criteria
+        @include ? sc.includes(@include) : sc
       end
     end
   end

--- a/lib/sunspot/mongo/tasks.rb
+++ b/lib/sunspot/mongo/tasks.rb
@@ -1,20 +1,21 @@
-namespace :sunspot do
-  namespace :mongo do
-    desc "Reindex all models that include Sunspot::Mongo and are located in your application's models directory."
-    task :reindex, [:models] => :environment do |_t, args|
-      sunspot_models = if args[:models]
-                         args[:models].split('+').map(&:constantize)
-                       else
-                         all_files = Dir.glob(Rails.root.join('app', 'models', '**', '*.rb'))
-                         all_models = all_files.map { |path| File.basename(path, '.rb').camelize.constantize }
-                         all_models.select { |m| m.include?(Sunspot::Mongo) && m.searchable? }
-                       end
+# Delete reindex task registered by sunspot_rails
+tasks = Rake.application.instance_variable_get '@tasks'
+tasks.delete 'sunspot:reindex'
 
-      sunspot_models.each do |model|
-        puts "reindexing #{model}"
-        model.all.each(&:index)
-        Sunspot.commit
-      end
+namespace :sunspot do
+  desc "Reindex all models that include Sunspot::Mongo and are located in your application's models directory."
+  task :reindex, [:models] => :environment do |_t, args|
+    sunspot_models = if args[:models]
+                       args[:models].split('+').map(&:constantize)
+                     else
+                       Rails.application.eager_load!
+                       Sunspot.searchable # when a model calls searchable, it registers itself to Sunspot
+                     end
+
+    sunspot_models.each do |model|
+      puts "reindexing #{model}"
+      model.all.each(&:index)
+      Sunspot.commit
     end
   end
 end

--- a/lib/sunspot/mongo/version.rb
+++ b/lib/sunspot/mongo/version.rb
@@ -1,5 +1,5 @@
 module Sunspot
   module Mongo
-    VERSION = '1.1.1'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/sunspot_mongo_spec.rb
+++ b/spec/sunspot_mongo_spec.rb
@@ -19,6 +19,20 @@ describe 'Sunspot::Mongo' do
   if ENV['MONGOID_VERSION']
     describe MongoidTestDocument do
       it_behaves_like 'a mongo document'
+      it 'eager-loads associations specified through :include option' do
+        test_doc = subject.create title: 'So much foo, so little bar.'
+        test_tag = MongoidTestDocumentTag.create name: 'A tag'
+        text_doc.tags << test_tag
+        text_doc.save
+        test_doc.index!
+
+        search = subject.solr_search(include: :tags) do
+          fulltext 'foo'
+        end
+        expect(search.hits.length).to eql 1
+        expect(search.results.first).to eql test_doc
+        expect(search.results.first.ivar(:tags)).to match [test_tag]
+      end
     end
     describe 'test documents with options' do
       it 'should set sunspot_options' do

--- a/spec/support/models/mongoid.rb
+++ b/spec/support/models/mongoid.rb
@@ -4,7 +4,18 @@ class MongoidTestDocument
 
   field :title
 
+  has_and_belongs_to_many :tags, class_name: 'MongoidTestDocumentTag'
+
   searchable do
     text :title
   end
+end
+
+class MongoidTestDocumentTag
+  include Mongoid::Document
+  include Sunspot::Mongo
+
+  field :name
+
+  has_and_belongs_to_many :documents, class_name: 'MongoidTestDocument'
 end


### PR DESCRIPTION
This fixes issue #8 and rake sunspot:mongo:reindex.
I don't know if the rake task was working before mongoid 4.0, but on mongoid 4.0 it didn't.

I wrote a spec for my fix to #8, but I could not run specs (same issues as #7).

**I renamed sunspot:mongo:reindex to sunspot:reindex** (and updated the README).
The reason why I'm proposing this cange is that, to my knowledge, one cannot use sunspot with both AR models and Mongoid models.
Therefore I think it's better to give gem users a transparent interface to the reindexing task.

In case that you are against the task renaming, I can make a new PR.
