### PR TITLE
implements `reindex` on models and Mongoid searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 1.2.2 (Next)
 
 * Your contribution here.
+* [#14](https://github.com/derekharmel/sunspot_mongo/pull/14): Implemented `reindex` on models and Mongoid searches - [@tonyta](https://github.com/tonyta).
 
 #### 1.2.1 (2015/10/20)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Note: Mongoid adds `Article.search`, use `Article.solr_search` instead.
 
 If you are using Rails, objects are automatically indexed to Solr as a part of the save callbacks.
 
+You can reindex a collection by calling `.reindex` directly on the model class. When using Mongoid, `#reindex` can be called on a search scope or criteria, reindexing only the matching objects.
+
+``` ruby
+Article.reindex
+
+# Mongoid only
+Article.pending.reindex
+Article.where(status: "posted").reindex
+
+```
+Note: `#reindex` on a MongoMapper search will always reindex the **entire** collection.
+
 If you make a change to the object's "schema" (code in the searchable block), you must reindex all objects so the changes are reflected in Solr. Run:
 
 ```

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -24,4 +24,23 @@ shared_examples 'a mongo document' do
     expect(search.hits.length).to eql 1
     expect(search.results.first).to eql test_doc
   end
+
+  describe '#reindex' do
+    it 'should be able to reindex' do
+      expect(subject.solr_search.total).to be_zero
+      subject.create(title: 'Test 1')
+      subject.create(title: 'Test 2')
+      subject.reindex
+      expect(subject.solr_search.total).not_to be_zero
+      expect(subject.solr_search.total).to eq subject.count
+    end
+
+    it 'should be able to reindex the result of an ORM query', if: ENV['MONGOID_VERSION'] do
+      expect(subject.solr_search.total).to be_zero
+      2.times { subject.create(title: 'to reindex') }
+      2.times { subject.create(title: 'not to reindex') }
+      subject.where(title: 'to reindex').reindex
+      expect(subject.solr_search.total).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
Calling `reindex` on a Mongoid or MongoMapper model will reindex the
entire collection. When called on a Mongoid criteria, the reindex will
be scoped to that criteria.

Caveat: Calling `reindex` on a MongoMapper query will **NOT** scope the
reindex to the search. It will reindex the _entire_ collection.
