### PR TITLE
spec_helper improvements

### DIFF
--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -1,5 +1,0 @@
-module Rails
-  def self.root
-    Dir.pwd
-  end
-end


### PR DESCRIPTION
- No need to set default MONGOID_VERSION (done in Gemfile)
- Rails.root is defined directly as gem root directory
- Mongo logger is silent for Mongoid 5
- No need to mkdir '/tmp/sunspot_mongo_test/'
