### PR TITLE
Solr Polling in CI Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 services:
   - mongodb
 
+before_script:
+  - bash ./ci/start_solr_server
+
 language: ruby
 
 cache: bundler

--- a/ci/start_solr_server
+++ b/ci/start_solr_server
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+solr_port=8900
+max_pings=100
+num_pings=0
+
+bundle exec sunspot-solr start \
+  --port=$solr_port            \
+  --data-directory=data        \
+  --log-file=solr.log          \
+  --log-level=INFO             \
+
+echo -n "Polling Solr..."
+
+while true; do
+  sleep 0.1
+
+  ((num_pings++))
+  echo -n "."
+  curl http://localhost:$solr_port/solr/admin/ping &> /dev/null
+
+  if [ "$?" -eq 0 ]; then
+    echo
+    echo -e "\033[32mSolr server running on port $solr_port\033[m"
+    break
+  elif [ "$num_pings" -ge "$max_pings" ]; then
+    echo
+    echo -e "\033[31mCannot find Solr server on port $solr_port: max number of pings ($max_pings) reached\033[m"
+    exit 1
+  fi
+done
+
+exit 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,9 +32,6 @@ end
 # Load shared examples
 require 'shared_examples'
 
-@solr_pid = fork { `sunspot-solr start --log-file=solr.log --data-directory=data --log-level=INFO --port=8900` }
-sleep 5
-
 Sunspot.config.solr.url = 'http://127.0.0.1:8900/solr'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,17 @@ require 'sunspot_mongo'
 ROOT_PATH = Pathname(__FILE__).join('../..')
 Rails.define_singleton_method(:root) { ROOT_PATH }
 
+SOLR_PORT = '8900'
+SOLR_URL = "http://127.0.0.1:#{SOLR_PORT}/solr"
+
+begin
+  RSolr.connect(url: SOLR_URL).head('admin/ping')
+rescue RSolr::Error::ConnectionRefused
+  raise "Tests require a Solr server to be running on port #{SOLR_PORT}."
+else
+  Sunspot.config.solr.url = SOLR_URL
+end
+
 if ENV['MONGOID_VERSION']
   require 'mongoid'
   require 'support/models/mongoid'
@@ -31,8 +42,6 @@ end
 
 # Load shared examples
 require 'shared_examples'
-
-Sunspot.config.solr.url = 'http://127.0.0.1:8900/solr'
 
 RSpec.configure do |config|
   config.before :each do


### PR DESCRIPTION
In tests, we expect the Mongo server to already be running. Similarly, we will expect the same of the Solr server.

For CI, a script will launch Solr and then wait until it can be pinged before proceeding with running test script.

Ready for review 😸 
